### PR TITLE
feat: implement login with google sso (closes #46)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,15 @@ DEMO_MODE=false
 ADMIN_USERNAME=
 ADMIN_PASSWORD=
 
+# Used for Single Sign On (SSO).
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+# Only used for spinning up a rauthy container in
+# local dev environments
+RAUTHY_PORT=55434
+OIDC_ISSUER_URL=http://localhost:${RAUTHY_PORT}/auth/v1
+OIDC_ISSUER_NAME=Rauthy
+
 TLS_KEY=development_cert/localhost.key
 TLS_CERT=development_cert/localhost.crt
 

--- a/.sqlx/query-281d80fd76e152c9b5af82896f699f4a7124d6d49f0ceacf3e132120a212e11f.json
+++ b/.sqlx/query-281d80fd76e152c9b5af82896f699f4a7124d6d49f0ceacf3e132120a212e11f.json
@@ -17,6 +17,16 @@
         "ordinal": 2,
         "name": "username",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "oidc_id",
+        "type_info": "Text"
       }
     ],
     "parameters": {
@@ -26,8 +36,10 @@
     },
     "nullable": [
       false,
-      false,
-      false
+      true,
+      true,
+      true,
+      true
     ]
   },
   "hash": "281d80fd76e152c9b5af82896f699f4a7124d6d49f0ceacf3e132120a212e11f"

--- a/.sqlx/query-2e12e297b51ef897c883019ec664c1effb7572cbe480ba344c12466009763f9c.json
+++ b/.sqlx/query-2e12e297b51ef897c883019ec664c1effb7572cbe480ba344c12466009763f9c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        select * from users\n        where username = $1\n        ",
+  "query": "\n        select * from users\n        where oidc_id = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -42,5 +42,5 @@
       true
     ]
   },
-  "hash": "8ea4609ecabc6dbafc262aea24eab363ee25e0dc76c19721907a7768e1e1f8c3"
+  "hash": "2e12e297b51ef897c883019ec664c1effb7572cbe480ba344c12466009763f9c"
 }

--- a/.sqlx/query-a318ecb17b4c69ea9efe97c56237838ca73e27dc8c1842af21e59963ebf8c267.json
+++ b/.sqlx/query-a318ecb17b4c69ea9efe97c56237838ca73e27dc8c1842af21e59963ebf8c267.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        insert into users\n        (password_hash, username)\n        values ($1, $2)\n        returning *",
+  "query": "\n        insert into users\n        (email, oidc_id)\n        values ($1, $2)\n        returning *",
   "describe": {
     "columns": [
       {
@@ -17,6 +17,16 @@
         "ordinal": 2,
         "name": "username",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "oidc_id",
+        "type_info": "Text"
       }
     ],
     "parameters": {
@@ -27,9 +37,11 @@
     },
     "nullable": [
       false,
-      false,
-      false
+      true,
+      true,
+      true,
+      true
     ]
   },
-  "hash": "800d1231cb12ad43b4aeacc24ff7f9beff5117d45d22234cb4b0ae051d02524b"
+  "hash": "a318ecb17b4c69ea9efe97c56237838ca73e27dc8c1842af21e59963ebf8c267"
 }

--- a/.sqlx/query-cc0f9deb60e3e4834e165e1a3ea2383b7638652cb82d5b16ccd8c189c5c6a924.json
+++ b/.sqlx/query-cc0f9deb60e3e4834e165e1a3ea2383b7638652cb82d5b16ccd8c189c5c6a924.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        select * from users\n        where username = $1\n        ",
+  "query": "\n        insert into users\n        (username, password_hash)\n        values ($1, $2)\n        returning *\n        ",
   "describe": {
     "columns": [
       {
@@ -31,6 +31,7 @@
     ],
     "parameters": {
       "Left": [
+        "Text",
         "Text"
       ]
     },
@@ -42,5 +43,5 @@
       true
     ]
   },
-  "hash": "8ea4609ecabc6dbafc262aea24eab363ee25e0dc76c19721907a7768e1e1f8c3"
+  "hash": "cc0f9deb60e3e4834e165e1a3ea2383b7638652cb82d5b16ccd8c189c5c6a924"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,7 +154,7 @@ checksum = "a41603f7cdbf5ac4af60760f17253eb6adf6ec5b6f14a7ed830cf687d375f163"
 dependencies = [
  "askama",
  "axum-core",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -216,10 +231,10 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.4.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -249,8 +264,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -282,10 +297,10 @@ dependencies = [
  "arc-swap",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "rustls",
@@ -310,6 +325,18 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -372,6 +399,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +439,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "clap"
@@ -484,6 +532,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +587,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +606,68 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -578,12 +716,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -634,6 +846,22 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "flume"
@@ -799,6 +1027,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -808,8 +1037,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -817,6 +1048,36 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.4.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "h2"
@@ -829,7 +1090,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.1.0",
  "indexmap 2.4.0",
  "slab",
  "tokio",
@@ -929,6 +1190,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -940,12 +1212,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -956,8 +1239,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -984,6 +1267,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
@@ -991,15 +1298,29 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1010,12 +1331,41 @@ checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1054,6 +1404,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1068,10 +1419,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1087,6 +1453,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1142,9 +1517,10 @@ dependencies = [
  "garde",
  "http-body-util",
  "include_dir",
- "itertools",
+ "itertools 0.13.0",
  "listenfd",
  "mime_guess",
+ "openidconnect",
  "railwind",
  "rand",
  "serde",
@@ -1348,6 +1724,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom",
+ "http 0.2.12",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,10 +1759,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openidconnect"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http 0.2.12",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1498,6 +1959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +2094,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +2230,15 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1808,6 +2338,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
 name = "serde"
 version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +2374,16 @@ checksum = "0d2e8bfba469d06512e11e3311d4d051a4a387a5b42d010404fecf3200321c95"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -1860,6 +2420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2459,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.4.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2271,6 +2870,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,7 +3102,7 @@ dependencies = [
  "axum-core",
  "cookie",
  "futures-util",
- "http",
+ "http 1.1.0",
  "parking_lot",
  "pin-project-lite",
  "tower-layer",
@@ -2497,8 +3117,8 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -2538,7 +3158,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "futures",
- "http",
+ "http 1.1.0",
  "parking_lot",
  "serde",
  "serde_json",
@@ -2641,6 +3261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +3335,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2774,6 +3401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,6 +3420,83 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -2831,6 +3544,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2979,6 +3701,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0.125"
 serde_qs = "0.13.0"
 sqlx = { version = "0.7.4", features = ["runtime-tokio", "postgres", "tls-rustls", "migrate", "uuid", "time"] }
 thiserror = "1.0.63"
+openidconnect="3.5.0"
 time = { version = "0.3.36", default-features = false, features = ["serde"] }
 tokio = { version = "1.39.3", features = ["macros", "rt-multi-thread", "signal"] }
 tower = { version = "0.5.0", features = ["util"] }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ cargo bin just watch
 
 Then, open [http://localhost:4040] in your browser.
 
+### Testing SSO with Rauthy
+
+1. Run `just start-rauthy` to run [rauthy](https://github.com/sebadob/rauthy) in development mode in a container.
+1. Open rauthy in your browser by going to localhost with the port specified by `RAUTHY_PORT` in your `.env` file.
+1. Go to the admin area and log in as `admin@localhost.de` with the password `test`.
+1. Create a new client. Use `{BASE_URL}/login_oidc_redirect` as your redirect URI, with the base URL defined in your `.env` file. Set access and id algorithm to one starting with "RS".
+1. Enter your client ID and secret in your `.env` file.
+1. Restart the linkblocks server. On the login page, there should be a "Sign in with Rauthy" button. If it's not there, check the server logs to see if something related to OIDC went wrong.
+
 ## Hosting Your Own Instance
 
 ⚠️ linkblocks is in a pre-alpha stage. There are no versions and no changelog. Expect data loss.

--- a/migrations/20240424165115_add_users_oauth.sql
+++ b/migrations/20240424165115_add_users_oauth.sql
@@ -1,0 +1,9 @@
+alter table users
+    add column email text
+        default null,
+    add column oidc_id text
+        default null,
+    alter column username
+        drop not null,
+    alter column password_hash
+        drop not null;

--- a/src/forms/users.rs
+++ b/src/forms/users.rs
@@ -1,4 +1,5 @@
 use garde::Validate;
+use openidconnect::{AuthorizationCode, CsrfToken};
 use serde::{Deserialize, Serialize};
 
 #[derive(Validate)]
@@ -23,4 +24,18 @@ pub struct Credentials {
     pub username: String,
     #[garde(length(min = 10, max = 100))]
     pub password: String,
+}
+
+#[derive(Deserialize)]
+pub struct OidcLoginQuery {
+    pub code: AuthorizationCode,
+    pub state: CsrfToken,
+}
+
+#[derive(Serialize, Deserialize, Validate, Debug, Default)]
+pub struct CreateOidcUser {
+    #[garde(length(min = 10, max = 100))]
+    pub oidc_id: String,
+    #[garde(length(min = 10, max = 100))]
+    pub email: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod db;
 mod extract;
 mod form_errors;
 mod forms;
+mod oidc;
 mod response_error;
 mod routes;
 pub mod server;

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1,0 +1,184 @@
+use anyhow::{anyhow, Context};
+use openidconnect::url::Url;
+use serde::{Deserialize, Serialize};
+
+use openidconnect::core::{
+    CoreClient, CoreIdTokenVerifier, CoreProviderMetadata, CoreResponseType,
+};
+use openidconnect::reqwest::async_http_client;
+use openidconnect::{
+    AccessTokenHash, AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
+    IssuerUrl, Nonce, OAuth2TokenResponse, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope,
+};
+use tower_sessions::Session;
+
+use crate::cli::OidcArgs;
+use crate::forms::users::CreateOidcUser;
+use crate::response_error::ResponseResult;
+
+#[derive(Serialize, Deserialize)]
+pub struct LoginAttempt {
+    pub nonce: Nonce,
+    pub csrf_token: CsrfToken,
+    pub pkce_verifier: PkceCodeVerifier,
+    pub authorize_url: Url,
+}
+
+impl LoginAttempt {
+    const SESSION_KEY: &'static str = "oidc_session";
+
+    pub fn new(client: &CoreClient) -> Self {
+        let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+        // Generate the authorization URL to which we'll redirect the user.
+        let (authorize_url, csrf_token, nonce) = client
+            .authorize_url(
+                AuthenticationFlow::<CoreResponseType>::AuthorizationCode,
+                CsrfToken::new_random,
+                Nonce::new_random,
+            )
+            .add_scope(Scope::new("email".to_string()))
+            .add_scope(Scope::new("profile".to_string()))
+            .set_pkce_challenge(pkce_challenge)
+            .url();
+
+        LoginAttempt {
+            nonce,
+            csrf_token,
+            pkce_verifier,
+            authorize_url,
+        }
+    }
+
+    pub async fn save_in_session(self, session: &Session) -> ResponseResult<()> {
+        session
+            .insert(Self::SESSION_KEY, self)
+            .await
+            .context("Failed to insert oidc data into session")?;
+
+        Ok(())
+    }
+
+    pub async fn from_session(session: &Session) -> ResponseResult<Self> {
+        Ok(session
+            .get(Self::SESSION_KEY)
+            .await
+            .context("Failed to load oidc data from session")?
+            .context("oidc data not found in session")?)
+    }
+
+    pub async fn login(
+        self,
+        oidc_client: &CoreClient,
+        csrf_token: CsrfToken,
+        code: AuthorizationCode,
+    ) -> ResponseResult<CreateOidcUser> {
+        if csrf_token.secret() != self.csrf_token.secret() {
+            return Err(anyhow!("CSRF token mismatch").into());
+        }
+        let token_response = oidc_client
+            .clone()
+            .exchange_code(code)
+            .set_pkce_verifier(self.pkce_verifier)
+            .request_async(async_http_client)
+            .await
+            .context("failed to get token response")?;
+        let id_token_verifier: CoreIdTokenVerifier = oidc_client.id_token_verifier();
+        let id_token = token_response
+            .extra_fields()
+            .id_token()
+            .context("Server did not return an ID token")?;
+        let id_token_claims = id_token
+            .claims(&id_token_verifier, &self.nonce)
+            .context("failed to get token claims")?;
+
+        if let Some(expected_access_token_hash) = id_token_claims.access_token_hash() {
+            let actual_access_token_hash = AccessTokenHash::from_token(
+                token_response.access_token(),
+                &id_token
+                    .signing_alg()
+                    .context("failed to get signing algorithm")?,
+            )
+            .context("Failed to get access token hash from token response")?;
+            if actual_access_token_hash != *expected_access_token_hash {
+                return Err(anyhow!("Invalid access token").into());
+            }
+        }
+
+        let email = id_token_claims
+            .email()
+            .context("failed to get email")?
+            .to_string();
+
+        let oidc_id = id_token_claims.subject().to_string();
+
+        Ok(CreateOidcUser { oidc_id, email })
+    }
+}
+
+#[derive(Clone)]
+pub struct Config {
+    pub client: CoreClient,
+    pub name: String,
+}
+
+// This enum is basically an Option with additional
+// semantics. As such, it's expected that the
+// `NotConfigured` variant will take up lots of space,
+// Just like `None` would
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
+pub enum State {
+    NotConfigured,
+    Configured(Config),
+}
+
+impl State {
+    #[must_use]
+    pub fn get_client(self) -> Option<CoreClient> {
+        match self {
+            State::NotConfigured => None,
+            State::Configured(Config { client, name: _ }) => Some(client),
+        }
+    }
+
+    pub async fn initialize(base_url: String, args: Option<OidcArgs>) -> State {
+        match Self::try_initialize_state(base_url, args).await {
+            Ok(conf) => {
+                tracing::info!("OIDC enabled.");
+                State::Configured(conf)
+            }
+            Err(e) => {
+                tracing::info!("OIDC disabled: {e:?}");
+                State::NotConfigured
+            }
+        }
+    }
+
+    async fn try_initialize_state(
+        base_url: String,
+        args: Option<OidcArgs>,
+    ) -> anyhow::Result<Config> {
+        let args = args.context("OIDC configuration is absent or incomplete.")?;
+        let client_id = ClientId::new(args.oidc_client_id);
+        let client_secret = ClientSecret::new(args.oidc_client_secret);
+        let issuer_url =
+            IssuerUrl::new(args.oidc_issuer_url).context("failed to parse issuer URL")?;
+
+        let provider_metadata = CoreProviderMetadata::discover_async(issuer_url, async_http_client)
+            .await
+            .context("failed to discover provider")?;
+        // Set up the config for the OIDC process.
+        let client =
+            CoreClient::from_provider_metadata(provider_metadata, client_id, Some(client_secret))
+                .set_redirect_uri(
+                    RedirectUrl::new(base_url + "/login_oidc_redirect")
+                        .context("Invalid redirect URL")?,
+                );
+
+        Ok(Config {
+            client,
+            name: args.oidc_issuer_name,
+        })
+    }
+}

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use askama_axum::IntoResponse;
 use axum::{
     extract::{Query, State},
@@ -6,21 +7,24 @@ use axum::{
     Router,
 };
 use garde::{Report, Validate};
-use serde::Deserialize;
 use tower_sessions::Session;
 
 use crate::{
     authentication::{self, AuthUser},
     extract::{self, qs_form::QsForm},
-    forms::users::Login,
+    forms::users::{Login, OidcLoginQuery},
+    oidc,
     response_error::ResponseResult,
     server::AppState,
     views::{layout, login, users::ProfileTemplate},
 };
+use serde::Deserialize;
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/login", get(get_login).post(post_login))
+        .route("/login_oidc_redirect", get(get_login_oidc_redirect))
+        .route("/login_oidc", get(get_login_oidc))
         .route("/login_demo", post(post_login_demo))
         .route("/logout", post(logout))
         .route("/profile", get(get_profile))
@@ -29,10 +33,11 @@ pub fn router() -> Router<AppState> {
 async fn post_login(
     extract::Tx(mut tx): extract::Tx,
     session: Session,
+    State(state): State<AppState>,
     QsForm(input): QsForm<Login>,
 ) -> ResponseResult<Response> {
     if let Err(errors) = input.validate() {
-        return Ok(login::Template::new(errors, input).into_response());
+        return Ok(login::Template::new(errors, input, state.oidc_state).into_response());
     };
 
     let logged_in = authentication::login(&mut tx, session, &input.credentials).await;
@@ -42,12 +47,46 @@ async fn post_login(
             garde::Path::new("root"),
             garde::Error::new("Username or password not correct"),
         );
-        return Ok(login::Template::new(errors, input).into_response());
+        return Ok(login::Template::new(errors, input, state.oidc_state).into_response());
     }
 
     let redirect_to = input.previous_uri.unwrap_or("/".to_string());
 
     Ok(Redirect::to(&redirect_to).into_response())
+}
+
+async fn get_login_oidc(
+    State(state): State<AppState>,
+    session: Session,
+) -> ResponseResult<Response> {
+    // TODO: Store the CSRF and none states in a way that is more secure than this, although the current method is already quite secure.
+    let client = state
+        .oidc_state
+        .get_client()
+        .context("OIDC client not configured")?;
+    let attempt = oidc::LoginAttempt::new(&client);
+    let authorize_url = attempt.authorize_url.clone();
+    attempt.save_in_session(&session).await?;
+
+    Ok(Redirect::to(authorize_url.as_str()).into_response())
+}
+
+async fn get_login_oidc_redirect(
+    session: Session,
+    Query(query): Query<OidcLoginQuery>,
+    state: State<AppState>,
+    extract::Tx(mut tx): extract::Tx,
+) -> ResponseResult<Response> {
+    let oidc_client = state
+        .oidc_state
+        .clone()
+        .get_client()
+        .context("OIDC client not configured")?;
+
+    authentication::login_oidc_user(&mut tx, &session, query, oidc_client).await?;
+
+    tx.commit().await?;
+    Ok(Redirect::to("/").into_response())
 }
 
 async fn post_login_demo(
@@ -78,6 +117,7 @@ async fn get_login(
                 previous_uri: query.previous_uri,
                 ..Default::default()
             },
+            state.oidc_state,
         )
         .into_response())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,7 @@ use tower_sessions::ExpiredDeletion;
 use crate::{
     cli::ListenArgs,
     db::{self},
-    routes,
+    oidc, routes,
 };
 
 use axum::Router;
@@ -20,6 +20,7 @@ pub struct AppState {
     pub pool: sqlx::PgPool,
     pub base_url: String,
     pub demo_mode: bool,
+    pub oidc_state: oidc::State,
 }
 
 pub async fn app(state: AppState) -> anyhow::Result<Router> {

--- a/src/tests/util/mod.rs
+++ b/src/tests/util/mod.rs
@@ -19,6 +19,7 @@ impl TestApp {
                 pool,
                 base_url: String::new(),
                 demo_mode: false,
+                oidc_state: crate::oidc::State::NotConfigured,
             })
             .await
             .unwrap(),

--- a/src/views/layout.rs
+++ b/src/views/layout.rs
@@ -12,8 +12,15 @@ pub struct Template {
 impl Template {
     pub async fn from_db(tx: &mut AppTx, auth_user: &AuthUser) -> ResponseResult<Self> {
         let pinned_lists = db::lists::list_pinned_by_user(tx, auth_user.user_id).await?;
+        let logged_in_username = auth_user
+            .user
+            .username
+            .as_ref()
+            .or(auth_user.user.email.as_ref())
+            .unwrap_or(&String::new())
+            .clone();
         Ok(Template {
-            logged_in_username: auth_user.user.username.clone(),
+            logged_in_username,
             lists: pinned_lists,
         })
     }

--- a/src/views/login.rs
+++ b/src/views/login.rs
@@ -3,17 +3,39 @@ use garde::Report;
 use crate::{
     form_errors::FormErrors,
     forms::users::{Credentials, Login},
+    oidc,
 };
+
+pub enum OidcInfo {
+    NotConfigured,
+    Configured { name: String },
+}
+
+impl Default for OidcInfo {
+    fn default() -> Self {
+        Self::NotConfigured
+    }
+}
+
+impl From<oidc::State> for OidcInfo {
+    fn from(value: oidc::State) -> Self {
+        match value {
+            oidc::State::NotConfigured => Self::NotConfigured,
+            oidc::State::Configured(oidc::Config { client: _, name }) => Self::Configured { name },
+        }
+    }
+}
 
 #[derive(askama::Template, Default)]
 #[template(path = "login.html")]
 pub struct Template {
     errors: FormErrors,
     input: Login,
+    oidc_info: OidcInfo,
 }
 
 impl Template {
-    pub fn new(errors: Report, input: Login) -> Self {
+    pub fn new(errors: Report, input: Login, oidc_state: oidc::State) -> Self {
         Self {
             errors: errors.into(),
             input: Login {
@@ -24,6 +46,7 @@ impl Template {
                 },
                 ..input
             },
+            oidc_info: oidc_state.into(),
         }
     }
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,53 +1,64 @@
 {% import "_form.html" as form %} {% extends "_base.html" %}
 {% block body %}
-  <form
-    action="/login"
-    method="post"
-    class="flex flex-col justify-center flex-1 max-w-md min-h-full px-4 mx-auto"
-    hx-boost="true"
-    hx-disabled-elt="button"
-  >
-    <h1 class="text-2xl font-bold tracking-tight text-center">
-      Sign in to your account
-    </h1>
-    <label class="mt-10 text-neutral-400" name="credentials[username]"
-      >Username</label
+  <div class="flex flex-col justify-center max-w-md min-h-full px-4 mx-auto">
+    <form
+      action="/login"
+      method="post"
+      hx-boost="true"
+      hx-disabled-elt="button"
+      class="flex flex-col w-full"
     >
-    {%
-      call form::errors(errors,
-      "credentials.username")
-    %}
-    <input
-      type="text"
-      name="credentials[username]"
-      class="rounded py-1.5 px-3 mt-2 bg-neutral-900"
-      value="{{ input.credentials.username }}"
-      required
-    />
-    <label for="credentials[password]" class="mt-4 text-neutral-400"
-      >Password</label
-    >
-    {% call form::errors(errors, "credentials.password") %}
-    <input
-      type="password"
-      name="credentials[password]"
-      class="rounded py-1.5 px-3 mt-2 bg-neutral-900"
-      required
-    />
-    {% if let Some(previous_uri) = input.previous_uri %}
-      <input type="hidden" name="previous_uri" value="{{ previous_uri }}" />
+      <h1 class="text-2xl font-bold tracking-tight text-center">
+        Sign in to your account
+      </h1>
+      <label class="mt-10 text-neutral-400" name="credentials[username]"
+        >Username</label
+      >
+      {%
+        call form::errors(errors,
+        "credentials.username")
+      %}
+      <input
+        type="text"
+        name="credentials[username]"
+        class="rounded py-1.5 px-3 mt-2 bg-neutral-900"
+        value="{{ input.credentials.username }}"
+        required
+      />
+      <label for="credentials[password]" class="mt-4 text-neutral-400"
+        >Password</label
+      >
+      {% call form::errors(errors, "credentials.password") %}
+      <input
+        type="password"
+        name="credentials[password]"
+        class="rounded py-1.5 px-3 mt-2 bg-neutral-900"
+        required
+      />
+      {% if let Some(previous_uri) = input.previous_uri %}
+        <input type="hidden" name="previous_uri" value="{{ previous_uri }}" />
+      {% endif %}
+      {% call form::errors(errors, "root") %}
+      <button
+        type="submit"
+        class="leading-6 bg-neutral-300 mt-5 font-semibold rounded py-1.5 flex items-center justify-center disabled:bg-neutral-500 text-neutral-900"
+      >
+        <span class="inline-block w-0 h-4">
+          <span
+            class="block w-4 h-4 -ml-6 border-2 rounded-full border-neutral-900 animate-spin border-t-transparent htmx-indicator"
+          ></span
+        ></span>
+        Sign in
+      </button>
+    </form>
+    {% if let OidcInfo::Configured{name} = oidc_info %}
+      <hr class="my-5 border-neutral-700" />
+      <a
+        class="leading-6 border border-neutral-500 font-semibold rounded py-1.5 flex items-center justify-center"
+        href="/login_oidc"
+      >
+        Sign in with {{ name }}
+      </a>
     {% endif %}
-    {% call form::errors(errors, "root") %}
-    <button
-      type="submit"
-      class="leading-6 bg-neutral-300 mt-5 font-semibold rounded py-1.5 flex items-center justify-center disabled:bg-neutral-500 text-neutral-900"
-    >
-      <span class="inline-block w-0 h-4">
-        <span
-          class="block w-4 h-4 -ml-6 border-2 rounded-full border-neutral-900 animate-spin border-t-transparent htmx-indicator"
-        ></span
-      ></span>
-      Sign in
-    </button>
-  </form>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Integrated [openidconnect](https://crates.io/crates/openidconnect) features and reused [axum-oidc](https://crates.io/crates/axum-oidc) code and features to implement a single sign-on feature for linkblocks. The current approach is to use `openidconnect` to reach out to the oauth party and return the user's data which is subsequently handled by a middleware (which partially reused `axum-oidc` code) to process the user authentication states. Everything made here is integrated with the current `linkblocks` approach of handling user data, so yeah having Google SSO will be pretty chill here :)

Despite the current implementation only handling Google single sign-on, the code done in this PR ensures that adding other provider's SSOs will be very easy in the future.

To actually use this PR, please go to the [google developer console](https://console.cloud.google.com/apis/dashboard), select a project (or create one if none), and create an OAuth2 Client2 under the Credentials tab. There, you will get Client Id and Client Secret which will be stored in the environmental variable (`.env`) as `OAUTH_GOOGLE_CLIENT_ID` and `OAUTH_GOOGLE_CLIENT_SECRET` respectively, and finally, you will have linkblocks running with SSO!

Wish that this PR could be accepted soon!