### PR TITLE
feat: make list public by default

### DIFF
--- a/.sqlx/query-4b838eb44c8c6fb60069894f80e9b4702faca004c4daf9d140cc9152929119eb.json
+++ b/.sqlx/query-4b838eb44c8c6fb60069894f80e9b4702faca004c4daf9d140cc9152929119eb.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        insert into lists\n        (user_id, title, content)\n        values ($1, $2, $3)\n        returning *",
+  "query": "\n        insert into lists\n        (user_id, title, content, private)\n        values ($1, $2, $3, $4)\n        returning *",
   "describe": {
     "columns": [
       {
@@ -27,13 +27,19 @@
         "ordinal": 4,
         "name": "content",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "private",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Left": [
         "Uuid",
         "Text",
-        "Text"
+        "Text",
+        "Bool"
       ]
     },
     "nullable": [
@@ -41,8 +47,9 @@
       false,
       false,
       false,
-      true
+      true,
+      false
     ]
   },
-  "hash": "7c13b69cf19a9af9b66ca4f53ca588e44f285d3028a2dfc9964d57e1bbf685a6"
+  "hash": "4b838eb44c8c6fb60069894f80e9b4702faca004c4daf9d140cc9152929119eb"
 }

--- a/.sqlx/query-55a06e706a68d350a7ac6d583a4dc3ba75c887dab8fba0a9e78ebb54c881121c.json
+++ b/.sqlx/query-55a06e706a68d350a7ac6d583a4dc3ba75c887dab8fba0a9e78ebb54c881121c.json
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "content",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "private",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -40,7 +45,8 @@
       false,
       false,
       false,
-      true
+      true,
+      false
     ]
   },
   "hash": "55a06e706a68d350a7ac6d583a4dc3ba75c887dab8fba0a9e78ebb54c881121c"

--- a/.sqlx/query-84b7723d8cf4570bc9bc05aa184d9cd0c4d6cab797c1f3cfc0ef2b3164def183.json
+++ b/.sqlx/query-84b7723d8cf4570bc9bc05aa184d9cd0c4d6cab797c1f3cfc0ef2b3164def183.json
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "content",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "private",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -39,7 +44,8 @@
       false,
       false,
       false,
-      true
+      true,
+      false
     ]
   },
   "hash": "84b7723d8cf4570bc9bc05aa184d9cd0c4d6cab797c1f3cfc0ef2b3164def183"

--- a/.sqlx/query-93c7a7586d32b00b3dcd571e20bf5e8b5d720e06f9f3b5ab4e1ef7da2e21f9aa.json
+++ b/.sqlx/query-93c7a7586d32b00b3dcd571e20bf5e8b5d720e06f9f3b5ab4e1ef7da2e21f9aa.json
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "content",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "private",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -39,7 +44,8 @@
       false,
       false,
       false,
-      true
+      true,
+      false
     ]
   },
   "hash": "93c7a7586d32b00b3dcd571e20bf5e8b5d720e06f9f3b5ab4e1ef7da2e21f9aa"

--- a/.sqlx/query-bd021bad7c5345082cd794a54b46dedca969f9d16d9bcaaf55de3d0dcdd38894.json
+++ b/.sqlx/query-bd021bad7c5345082cd794a54b46dedca969f9d16d9bcaaf55de3d0dcdd38894.json
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "content",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "private",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -39,7 +44,8 @@
       false,
       false,
       false,
-      true
+      true,
+      false
     ]
   },
   "hash": "bd021bad7c5345082cd794a54b46dedca969f9d16d9bcaaf55de3d0dcdd38894"

--- a/.sqlx/query-f9aad0e60b717a8cb71aa74dd158fdd018e0e1ba324f876f70f55b178d8069d4.json
+++ b/.sqlx/query-f9aad0e60b717a8cb71aa74dd158fdd018e0e1ba324f876f70f55b178d8069d4.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select lists.*\n            from lists\n            left join links as src_links on lists.id = src_links.src_list_id\n            left join links as dest_links on lists.id = dest_links.dest_list_id\n            where lists.user_id = $1\n            group by lists.id\n            order by\n                max(src_links.created_at) desc nulls last,\n                max(dest_links.created_at) nulls last,\n                max(lists.created_at) desc\n            limit 10\n        ",
+  "query": "\n        update lists\n        set private = $1\n        where id = $2\n        returning *\n        ",
   "describe": {
     "columns": [
       {
@@ -36,6 +36,7 @@
     ],
     "parameters": {
       "Left": [
+        "Bool",
         "Uuid"
       ]
     },
@@ -48,5 +49,5 @@
       false
     ]
   },
-  "hash": "bf78d8c6464f39f3c33ee565e305dd7593734983c97fe9ba14f67016673e7bf1"
+  "hash": "f9aad0e60b717a8cb71aa74dd158fdd018e0e1ba324f876f70f55b178d8069d4"
 }

--- a/migrations/20240426170949_public_lists.sql
+++ b/migrations/20240426170949_public_lists.sql
@@ -1,0 +1,5 @@
+alter table lists
+    add column private boolean
+        not null
+        default false;
+        

--- a/src/db/lists.rs
+++ b/src/db/lists.rs
@@ -21,6 +21,7 @@ pub struct List {
 
     pub title: String,
     pub content: Option<String>,
+    pub private: bool,
 }
 
 impl List {
@@ -47,12 +48,13 @@ pub async fn insert(
         List,
         r#"
         insert into lists
-        (user_id, title, content)
-        values ($1, $2, $3)
+        (user_id, title, content, private)
+        values ($1, $2, $3, $4)
         returning *"#,
         user_id,
         create_list.title,
         create_list.content,
+        create_list.private,
     )
     .fetch_one(&mut **tx)
     .await?;
@@ -146,4 +148,22 @@ pub async fn list_recent(tx: &mut AppTx, user_id: Uuid) -> ResponseResult<Vec<Li
     .await?;
 
     Ok(lists)
+}
+
+pub async fn set_private(tx: &mut AppTx, list_id: Uuid, private: bool) -> ResponseResult<List> {
+    let list = query_as!(
+        List,
+        r#"
+        update lists
+        set private = $1
+        where id = $2
+        returning *
+        "#,
+        private,
+        list_id,
+    )
+    .fetch_one(&mut **tx)
+    .await?;
+
+    Ok(list)
 }

--- a/src/forms/lists.rs
+++ b/src/forms/lists.rs
@@ -7,4 +7,12 @@ pub struct CreateList {
     pub title: String,
     #[garde(skip)]
     pub content: Option<String>,
+    #[garde(skip)]
+    #[serde(default)]
+    pub private: bool,
+}
+
+#[derive(Deserialize)]
+pub struct EditListPrivate {
+    pub private: bool,
 }

--- a/src/insert_demo_data.rs
+++ b/src/insert_demo_data.rs
@@ -56,6 +56,7 @@ pub async fn insert_demo_data(
             let create_list = CreateList {
                 title,
                 content: content.map(|c| c.join("\n\n")),
+                private: fake::Faker.fake(),
             };
             let list = db::lists::insert(&mut tx, user.id, create_list).await?;
 

--- a/src/routes/bookmarks.rs
+++ b/src/routes/bookmarks.rs
@@ -38,7 +38,7 @@ async fn post_create(
     auth_user: AuthUser,
     QsForm(input): QsForm<CreateBookmark>,
 ) -> ResponseResult<Response> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
 
     dbg!(&input);
     let selected_parents = db::lists::list_by_id(&mut tx, &input.parents).await?;
@@ -72,6 +72,7 @@ async fn post_create(
             CreateList {
                 title: parent_title,
                 content: None,
+                private: false,
             },
         )
         .await?;
@@ -123,7 +124,7 @@ async fn get_create(
     auth_user: AuthUser,
     Query(query): Query<CreateBookmarkQuery>,
 ) -> ResponseResult<CreateBookmarkTemplate> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
 
     let selected_parent = match query.parent_id {
         Some(id) => Some(db::lists::by_id(&mut tx, id).await?),
@@ -148,7 +149,7 @@ async fn get_unsorted(
     extract::Tx(mut tx): extract::Tx,
     auth_user: AuthUser,
 ) -> ResponseResult<UnsortedBookmarksTemplate> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
     let bookmarks = db::bookmarks::list_unsorted(&mut tx, auth_user.user_id).await?;
 
     Ok(UnsortedBookmarksTemplate { layout, bookmarks })

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -16,6 +16,6 @@ async fn index(
     extract::Tx(mut tx): extract::Tx,
 ) -> ResponseResult<views::index::Template> {
     Ok(views::index::Template {
-        layout: layout::Template::from_db(&mut tx, &auth_user).await?,
+        layout: layout::Template::from_db(&mut tx, Some(&auth_user)).await?,
     })
 }

--- a/src/routes/links.rs
+++ b/src/routes/links.rs
@@ -34,7 +34,7 @@ async fn post_create(
     // TODO handle failed extractors in forms better
     QsForm(input): QsForm<PartialCreateLink>,
 ) -> ResponseResult<Response> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
     let src_from_db = match input.src {
         Some(id) => Some(db::items::by_id(&mut tx, id).await?),
         None => None,
@@ -105,7 +105,7 @@ async fn get_create(
     auth_user: AuthUser,
     Query(query): Query<CreateLinkQueryString>,
 ) -> ResponseResult<CreateLinkTemplate> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
 
     let src = match query.src_id {
         Some(id) => Some(db::items::by_id(&mut tx, id).await?),

--- a/src/routes/lists.rs
+++ b/src/routes/lists.rs
@@ -1,5 +1,6 @@
 use crate::form_errors::FormErrors;
-use crate::forms::lists::CreateList;
+use crate::forms::lists::{CreateList, EditListPrivate};
+use crate::response_error::ResponseError;
 use crate::server::AppState;
 use crate::views::lists::CreateListTemplate;
 use crate::{authentication::AuthUser, response_error::ResponseResult};
@@ -12,6 +13,7 @@ use askama_axum::IntoResponse;
 use axum::extract::Path;
 use axum::response::Redirect;
 use axum::response::Response;
+use axum::routing::post;
 use axum::Form;
 use axum::{routing::get, Router};
 use garde::Validate;
@@ -22,18 +24,32 @@ pub fn router() -> Router<AppState> {
     router
         .route("/lists/create", get(get_create).post(post_create))
         .route("/lists/:list_id", get(list))
+        .route("/lists/:list_id/edit_private", post(toggle_publicity))
 }
 
 async fn list(
-    auth_user: AuthUser,
+    auth_user: Option<AuthUser>,
     extract::Tx(mut tx): extract::Tx,
     Path(list_id): Path<Uuid>,
 ) -> ResponseResult<ListTemplate> {
     let links = db::links::list_by_list(&mut tx, list_id).await?;
     let list = db::lists::by_id(&mut tx, list_id).await?;
 
+    match auth_user {
+        Some(ref user) => {
+            if list.private && list.user_id != user.user_id {
+                return Err(ResponseError::NotFound);
+            }
+        }
+        None => {
+            if list.private {
+                return Err(ResponseError::NotFound);
+            }
+        }
+    }
+
     Ok(ListTemplate {
-        layout: layout::Template::from_db(&mut tx, &auth_user).await?,
+        layout: layout::Template::from_db(&mut tx, auth_user.as_ref()).await?,
         links,
         list,
     })
@@ -44,7 +60,8 @@ async fn post_create(
     auth_user: AuthUser,
     Form(input): Form<CreateList>,
 ) -> ResponseResult<Response> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let user_id = auth_user.user_id;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
 
     if let Err(errors) = input.validate() {
         return Ok(views::lists::CreateListTemplate {
@@ -55,7 +72,7 @@ async fn post_create(
         .into_response());
     };
 
-    let list = db::lists::insert(&mut tx, auth_user.user_id, input).await?;
+    let list = db::lists::insert(&mut tx, user_id, input).await?;
 
     tx.commit().await?;
 
@@ -66,11 +83,30 @@ async fn get_create(
     extract::Tx(mut tx): extract::Tx,
     auth_user: AuthUser,
 ) -> ResponseResult<CreateListTemplate> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
 
     Ok(CreateListTemplate {
         layout,
         errors: FormErrors::default(),
         input: CreateList::default(),
     })
+}
+
+async fn toggle_publicity(
+    auth_user: AuthUser,
+    extract::Tx(mut tx): extract::Tx,
+    Path(list_id): Path<Uuid>,
+    Form(input): Form<EditListPrivate>,
+) -> ResponseResult<Response> {
+    let list = db::lists::by_id(&mut tx, list_id).await?;
+
+    if list.user_id != auth_user.user_id {
+        return Err(ResponseError::NotFound);
+    }
+
+    db::lists::set_private(&mut tx, list_id, input.private).await?;
+
+    tx.commit().await?;
+
+    Ok(Redirect::to(&list.path()).into_response())
 }

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -137,7 +137,7 @@ async fn get_profile(
     auth_user: AuthUser,
     State(state): State<AppState>,
 ) -> ResponseResult<ProfileTemplate> {
-    let layout = layout::Template::from_db(&mut tx, &auth_user).await?;
+    let layout = layout::Template::from_db(&mut tx, Some(&auth_user)).await?;
 
     Ok(ProfileTemplate {
         layout,

--- a/src/views/layout.rs
+++ b/src/views/layout.rs
@@ -7,21 +7,30 @@ use crate::{
 pub struct Template {
     pub logged_in_username: String,
     pub lists: Vec<db::List>,
+    pub authenticated: bool,
 }
 
 impl Template {
-    pub async fn from_db(tx: &mut AppTx, auth_user: &AuthUser) -> ResponseResult<Self> {
-        let pinned_lists = db::lists::list_pinned_by_user(tx, auth_user.user_id).await?;
-        let logged_in_username = auth_user
-            .user
-            .username
-            .as_ref()
-            .or(auth_user.user.email.as_ref())
-            .unwrap_or(&String::new())
-            .clone();
+    pub async fn from_db(tx: &mut AppTx, auth_user: Option<&AuthUser>) -> ResponseResult<Self> {
+        let (pinned_lists, logged_in_username) = if let Some(auth_user) = auth_user {
+            let logged_in_username = auth_user
+                .user
+                .username
+                .as_ref()
+                .or(auth_user.user.email.as_ref())
+                .unwrap_or(&String::new())
+                .clone();
+            (
+                db::lists::list_pinned_by_user(tx, auth_user.user_id).await?,
+                logged_in_username,
+            )
+        } else {
+            (Vec::new(), String::new())
+        };
         Ok(Template {
             logged_in_username,
             lists: pinned_lists,
+            authenticated: auth_user.is_some(),
         })
     }
 }

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -4,60 +4,62 @@
     <main class="sm:overflow-y-auto sm:grow">
       {% block content %}{% endblock %}
     </main>
-    <aside
-      id="nav"
-      class="bg-neutral-900 sm:max-w-[18rem] sm:w-1/3 sm:max-h-full flex flex-col sm:flex-col-reverse sm:border-r border-neutral-700 border-t sm:border-t-0"
-    >
-      <div class="sm:overflow-y-auto">
-        <div
-          class="sticky top-0 flex items-center justify-between px-2 pt-2 sm:top-0 bg-neutral-900"
-        >
-          <h3
-            class="px-2 py-1 text-sm font-bold tracking-tight text-neutral-400"
+    {% if layout.authenticated %}
+      <aside
+        id="nav"
+        class="bg-neutral-900 sm:max-w-[18rem] sm:w-1/3 sm:max-h-full flex flex-col sm:flex-col-reverse sm:border-r border-neutral-700 border-t sm:border-t-0"
+      >
+        <div class="sm:overflow-y-auto">
+          <div
+            class="sticky top-0 flex items-center justify-between px-2 pt-2 sm:top-0 bg-neutral-900"
           >
-            Lists
-          </h3>
-          <a
-            href="/lists/create"
-            class="block px-3 text-xl rounded hover:bg-neutral-800 text-neutral-400"
-            >+</a
-          >
-        </div>
-        <ul>
-          <li>
-            <a
-              class="block px-4 py-1 overflow-hidden text-ellipsis whitespace-nowrap hover:bg-neutral-800"
-              href="/bookmarks/unsorted"
+            <h3
+              class="px-2 py-1 text-sm font-bold tracking-tight text-neutral-400"
             >
-              Unsorted bookmarks
-            </a>
-          </li>
-          {% for list in layout.lists %}
+              Lists
+            </h3>
+            <a
+              href="/lists/create"
+              class="block px-3 text-xl rounded hover:bg-neutral-800 text-neutral-400"
+              >+</a
+            >
+          </div>
+          <ul>
             <li>
               <a
                 class="block px-4 py-1 overflow-hidden text-ellipsis whitespace-nowrap hover:bg-neutral-800"
-                href="/lists/{{ list.id }}"
+                href="/bookmarks/unsorted"
               >
-                {{ list.title }}
+                Unsorted bookmarks
               </a>
             </li>
-          {% endfor %}
-        </ul>
-      </div>
+            {% for list in layout.lists %}
+              <li>
+                <a
+                  class="block px-4 py-1 overflow-hidden text-ellipsis whitespace-nowrap hover:bg-neutral-800"
+                  href="/lists/{{ list.id }}"
+                >
+                  {{ list.title }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
 
-      <header
-        class="sticky bottom-0 flex justify-between p-2 leading-8 bg-neutral-900"
-      >
-        <a href="/" class="px-2 font-bold rounded hover:bg-neutral-800"
-          >{{ layout.logged_in_username }}</a
+        <header
+          class="sticky bottom-0 flex justify-between p-2 leading-8 bg-neutral-900"
         >
+          <a href="/" class="px-2 font-bold rounded hover:bg-neutral-800"
+            >{{ layout.logged_in_username }}</a
+          >
 
-        <form action="/logout" method="post">
-          <button class="px-3 rounded text-neutral-400 hover:bg-neutral-800">
-            Logout
-          </button>
-        </form>
-      </header>
-    </aside>
+          <form action="/logout" method="post">
+            <button class="px-3 rounded text-neutral-400 hover:bg-neutral-800">
+              Logout
+            </button>
+          </form>
+        </header>
+      </aside>
+    {% endif %}
   </div>
 {% endblock %}

--- a/templates/create_bookmark.html
+++ b/templates/create_bookmark.html
@@ -52,7 +52,8 @@
       {% call form::errors(errors, "create_parents") %}
       {% for parent_name in input.create_parents %}
         <label class="block leading-8">
-          New list <span class="text-fuchsia-100">🧵 {{ parent_name }}</span>
+          New public list
+          <span class="text-fuchsia-100">🧵 {{ parent_name }}</span>
           <input
             type="hidden"
             name="create_parents[]"
@@ -99,7 +100,7 @@
             hx-target="#selected_lists"
             class="block w-full px-4 pt-1 pb-2 text-left rounded hover:bg-neutral-700 text-fuchsia-100"
           >
-            Create list "{{ term }}"
+            Create public list "{{ term }}"
           </button>
         {% endif %}
       {% endif %}

--- a/templates/create_list.html
+++ b/templates/create_list.html
@@ -31,6 +31,20 @@
       ></textarea>
     </label>
 
+    <div class="mt-3 mb-5">
+      <label>
+        <input
+          type="checkbox"
+          name="private"
+          value="true"
+          {% if input.private %}
+            checked
+          {% endif %}
+        />
+        Private</label
+      >
+    </div>
+
     {% call form::errors(errors, "root") %}
 
     <button

--- a/templates/list.html
+++ b/templates/list.html
@@ -1,9 +1,11 @@
 {% import "_content.html" as content %}
 {% extends "_layout.html" %}
 {% block content %}
-  <header class="px-4 pt-3 mb-2">
+  <header class="px-4 pt-3 mb-4">
     <div class="flex items-center justify-between">
-      <h1 class="text-xl font-bold">{{ list.title }}</h1>
+      <h1 class="text-xl font-bold">
+        {% if list.private %}🔒&nbsp;{% endif %}{{ list.title }}
+      </h1>
     </div>
     {% if let Some(content) = list.content %}
       {% if !content.is_empty() %}
@@ -11,24 +13,47 @@
       {% endif %}
     {% endif %}
   </header>
-  <section class="flex my-4">
-    <a
-      href="/bookmarks/create?parent_id={{ list.id }}"
-      class="block px-4 py-1 ml-4 mr-2 border rounded hover:bg-neutral-700 border-neutral-700 w-max"
-      hx-get="/bookmarks/create?parent_id={{ list.id }}"
-      hx-target="closest section"
-      hx-select="#create_bookmark"
-      >Add new bookmark</a
-    >
-    <a
-      href="/links/create?src_id={{ list.id }}"
-      class="block px-4 py-1 mx-2 border rounded hover:bg-neutral-700 border-neutral-700 w-max"
-      hx-get="/links/create?src_id={{ list.id }}"
-      hx-target="closest section"
-      hx-select="#create_link"
-      >Link an item</a
-    >
-  </section>
+  {% if layout.authenticated %}
+    <section class="flex flex-wrap m-4 gap-x-4 gap-y-2">
+      <a
+        href="/bookmarks/create?parent_id={{ list.id }}"
+        class="block px-4 py-1 border rounded hover:bg-neutral-700 border-neutral-700 w-max"
+        hx-get="/bookmarks/create?parent_id={{ list.id }}"
+        hx-target="closest section"
+        hx-select="#create_bookmark"
+        >Add new bookmark</a
+      >
+      <a
+        href="/links/create?src_id={{ list.id }}"
+        class="block px-4 py-1 border rounded hover:bg-neutral-700 border-neutral-700 w-max"
+        hx-get="/links/create?src_id={{ list.id }}"
+        hx-target="closest section"
+        hx-select="#create_link"
+        >Link an item</a
+      >
+      <form
+        method="post"
+        action="/lists/{{ list.id }}/edit_private"
+        hx-post="/lists/{{ list.id }}/edit_private"
+        hx-select="#edit_private"
+        hx-target="this"
+        id="edit_private"
+      >
+        <button
+          class="block px-4 py-1 border rounded hover:bg-neutral-700 border-neutral-700 w-max"
+          name="private"
+          value="{{ !list.private }}"
+          type="submit"
+        >
+          {% if list.private %}
+            Make public
+          {% else %}
+            Make private
+          {% endif %}
+        </button>
+      </form>
+    </section>
+  {% endif %}
   {% for link in links %}
     <section
       class="flex flex-wrap items-end justify-between gap-2 px-4 pt-4 pb-4 border-t border-neutral-700"
@@ -87,25 +112,26 @@
           {% call content::link_url(bookmark.url) %}
         {% endmatch %}
       </div>
-
-      <div
-        class="flex flex-wrap justify-end pt-2 text-sm gap-x-2 text-neutral-400"
-      >
-        <a
-          class="hover:text-neutral-100"
-          href="/links/create?dest_id={{ link.dest.id() }}"
+      {% if layout.authenticated %}
+        <div
+          class="flex flex-wrap justify-end pt-2 text-sm gap-x-2 text-neutral-400"
         >
-          Add to other list
-        </a>
-        ∙
-        <button
-          class="hover:text-neutral-100"
-          hx-delete="/links/{{ link.id }}"
-          title="Remove from list"
-        >
-          Remove from this list
-        </button>
-      </div>
+          <a
+            class="hover:text-neutral-100"
+            href="/links/create?dest_id={{ link.dest.id() }}"
+          >
+            Add to other list
+          </a>
+          ∙
+          <button
+            class="hover:text-neutral-100"
+            hx-delete="/links/{{ link.id }}"
+            title="Remove from list"
+          >
+            Remove from this list
+          </button>
+        </div>
+      {% endif %}
     </section>
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Adding features mentioned in #44. I've made the lists part to be public by default after initial creation, making non-authenticated users able to see it just by opening the same link as what the authenticated users use to view their lists.

In order make this possible, I've created a new struct called `Authenticated` which does not force-checking every request and send them to the login page if not authenticated, instead it just simply says that "this is not authenticated" if it does not authenticated while returning the `auth_user` properties if authenticated. 

Then, I added a new column to the `lists`, called `prvate` (not `private` or `priv` as they are keywords so yeah I chose some random key), which is set to false as default. Finally, it uses conditional rendering according to the key. I've also added a button so that users are able to toggle the publicity of the list.