### PR TITLE
Do not allow to save links with an empty title

### DIFF
--- a/src/forms/bookmarks.rs
+++ b/src/forms/bookmarks.rs
@@ -40,6 +40,7 @@ impl TryFrom<CreateBookmark> for InsertBookmark {
     }
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn not_empty(value: &str, _: &()) -> garde::Result {
     if value.is_empty() {
         Err(garde::Error::new("cannot be empty"))

--- a/src/forms/bookmarks.rs
+++ b/src/forms/bookmarks.rs
@@ -14,7 +14,7 @@ pub struct CreateBookmark {
     pub create_parents: Vec<String>,
     #[garde(url)]
     pub url: String,
-    #[garde(skip)]
+    #[garde(custom(not_empty))]
     pub title: String,
     #[garde(length(max = 100))]
     pub list_search_term: Option<String>,
@@ -37,5 +37,13 @@ impl TryFrom<CreateBookmark> for InsertBookmark {
             url: value.url,
             title: value.title,
         })
+    }
+}
+
+fn not_empty(value: &String, _: &()) -> garde::Result {
+    if value.is_empty() {
+        Err(garde::Error::new("cannot be empty"))
+    } else {
+        Ok(())
     }
 }

--- a/src/forms/bookmarks.rs
+++ b/src/forms/bookmarks.rs
@@ -40,7 +40,7 @@ impl TryFrom<CreateBookmark> for InsertBookmark {
     }
 }
 
-fn not_empty(value: &String, _: &()) -> garde::Result {
+fn not_empty(value: &str, _: &()) -> garde::Result {
     if value.is_empty() {
         Err(garde::Error::new("cannot be empty"))
     } else {


### PR DESCRIPTION
When it was possible to do so, a link looked super weird in a list view and you were not able to click on a link and visit one. 

Here is a screenshot:
<img width="407" alt="image" src="https://github.com/user-attachments/assets/fa51f757-5aa7-4615-8e32-abec80206e71">

So, I decided to make a custom rule for garde. Now it looks like this: 
<img width="606" alt="image" src="https://github.com/user-attachments/assets/1b0f345b-d593-41e3-9582-adf5661e9ddc">

A better feature may become to create a somewhat title fetcher, when title is empty. A client sends get request and parses response body by looking for `<title>` tag, if there is none, finds a `<h1>` and so on. If nothing else found a message returned and users are asked to provide a title themselves.