### PR TITLE
Use cranelift backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+cargo-features = ["codegen-backend"]
+
+# TODO somehow this doesn't get applied in CI
+[profile.dev]
+codegen-backend = "cranelift"
+
 [package]
 name = "ties"
 version = "0.1.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -23,6 +23,7 @@ path = [
     ".config/*.toml",
     ".cargo/*.toml",
     "bin/*",
+    "rust-toolchain.toml",
 ]
 SPDX-FileCopyrightText = "ties Contributors"
 SPDX-License-Identifier = "AGPL-3.0-only"

--- a/bin/benchmark-hot-compilation.sh
+++ b/bin/benchmark-hot-compilation.sh
@@ -36,4 +36,4 @@ hyperfine \
     --max-runs 10 \
     --prepare "prepare_next" \
     --setup "make_change \$RANDOM" \
-    "cargo build"
+    "cargo +nightly build"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustc-codegen-cranelift-preview"]


### PR DESCRIPTION
It's not clear if the additional setup complexity is worth the compilation speed here.

On my desktop, with cranelift:
```
Time (mean ± σ):      1.482 s ±  0.053 s    [User: 1.225 s, System: 1.610 s]
  Range (min … max):    1.406 s …  1.544 s    10 runs
  ```

without cranelift:
```
  Time (mean ± σ):      1.649 s ±  0.043 s    [User: 1.950 s, System: 1.736 s]
  Range (min … max):    1.573 s …  1.705 s    10 runs
  ```