### PR TITLE
Adjust ActivityPub bookmark representation to match Betula

### DIFF
--- a/src/federation/activity.rs
+++ b/src/federation/activity.rs
@@ -6,10 +6,22 @@ use activitypub_federation::{
     traits::{ActivityHandler, Actor},
 };
 use serde::Serialize;
+use serde_json::{Value, json};
 use url::Url;
 use uuid::Uuid;
 
 use crate::{db, federation::context::Data};
+
+pub fn default_context() -> Value {
+    json!(["https://www.w3.org/ns/activitystreams"])
+}
+
+pub fn hashtag_context() -> Value {
+    json!([
+        "https://www.w3.org/ns/activitystreams",
+        { "Hashtag": "https://www.w3.org/ns/activitystreams#Hashtag" }
+    ])
+}
 
 pub async fn send<Activity, ActorType: Actor>(
     actor: &ActorType,
@@ -21,7 +33,21 @@ where
     Activity: ActivityHandler + Serialize + Debug + Send + Sync,
     <Activity as ActivityHandler>::Error: From<activitypub_federation::error::Error>,
 {
-    let activity = WithContext::new_default(activity);
+    send_with_context(actor, activity, default_context(), recipients, context).await
+}
+
+pub async fn send_with_context<Activity, ActorType: Actor>(
+    actor: &ActorType,
+    activity: Activity,
+    ap_context: Value,
+    recipients: &[&db::ApUser],
+    context: &Data,
+) -> Result<(), <Activity as ActivityHandler>::Error>
+where
+    Activity: ActivityHandler + Serialize + Debug + Send + Sync,
+    <Activity as ActivityHandler>::Error: From<activitypub_federation::error::Error>,
+{
+    let activity = WithContext::new(activity, ap_context);
     let inboxes = recipients
         .iter()
         .map(|ap_user| ap_user.shared_inbox_or_inbox())

--- a/src/federation/bookmark.rs
+++ b/src/federation/bookmark.rs
@@ -7,6 +7,7 @@ use activitypub_federation::{
 };
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 use url::Url;
 
 use crate::{
@@ -22,22 +23,54 @@ pub struct Json {
     pub kind: NoteType,
     pub attributed_to: ObjectId<db::ApUser>,
     pub to: Vec<Url>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub published: OffsetDateTime,
     /// Formatted content with the url inlined, for platforms that don't support
     /// link attachments
     pub content: Option<String>,
     /// The title
     pub name: Option<String>,
-    #[serde(default)]
+    /// Link to the bookmark's web view
+    pub url: Url,
+    /// The original markup the content was rendered from
+    // TODO for future description support
+    pub source: Source,
+    #[serde(rename = "attachment", default)]
     pub attachments: Vec<Link>,
+    /// Hashtags derived from the public lists this bookmark belongs to
+    #[serde(rename = "tag", default)]
+    pub tags: Vec<Hashtag>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Source {
+    pub content: String,
+    pub media_type: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Link {
     href: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     media_type: Option<String>,
     #[serde(rename = "type")]
     kind: LinkType,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Hashtag {
+    href: String,
+    name: String,
+    #[serde(rename = "type")]
+    kind: HashtagType,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum HashtagType {
+    Hashtag,
 }
 
 impl TryFrom<Json> for InsertBookmark {
@@ -97,14 +130,35 @@ impl Object for db::Bookmark {
             r#"<p>{}</p><a href="{}">{}</p>"#,
             self.title, self.url, self.url
         );
+        let followers = data.base_url.join("/followers")?;
+        let web_url = data.base_url.join(&self.path())?;
+
+        // None for public lists
+        let lists = db::lists::pointing_to_bookmark(&mut tx, self.id, None).await?;
+        let mut tags = Vec::with_capacity(lists.len());
+        for list in lists {
+            tags.push(Hashtag {
+                href: data.base_url.join(&list.path())?.to_string(),
+                name: format!("#{}", list.title),
+                kind: HashtagType::Hashtag,
+            });
+        }
+
         Ok(Json {
             id: self.ap_id,
             kind: NoteType::Note,
             attributed_to: author.ap_id,
-            to: vec![public()],
+            to: vec![public(), followers],
+            published: self.created_at,
             content: Some(content),
             name: Some(self.title),
+            url: web_url,
+            source: Source {
+                content: String::new(),
+                media_type: "text/plain".to_string(),
+            },
             attachments,
+            tags,
         })
     }
 

--- a/src/federation/bookmark.rs
+++ b/src/federation/bookmark.rs
@@ -130,7 +130,6 @@ impl Object for db::Bookmark {
             r#"<p>{}</p><a href="{}">{}</p>"#,
             self.title, self.url, self.url
         );
-        let followers = data.base_url.join("/followers")?;
         let web_url = data.base_url.join(&self.path())?;
 
         // None for public lists
@@ -148,7 +147,7 @@ impl Object for db::Bookmark {
             id: self.ap_id,
             kind: NoteType::Note,
             attributed_to: author.ap_id,
-            to: vec![public(), followers],
+            to: vec![public()],
             published: self.created_at,
             content: Some(content),
             name: Some(self.title),

--- a/src/federation/create_bookmark.rs
+++ b/src/federation/create_bookmark.rs
@@ -29,9 +29,7 @@ impl CreateBookmark {
         context: &super::Data,
     ) -> ResponseResult<()> {
         let object = bookmark.into_json(context).await?;
-        // Add ?create to id. Activity id has to be distinct from object id.
-        let mut id = object.id.inner().clone();
-        id.set_query(Some("create"));
+        let id = super::activity::generate_id(context)?;
 
         let mut tx = context.db_pool.begin().await?;
         let followers = db::ap_users::list_followers(&mut tx, actor.id).await?;

--- a/src/federation/create_bookmark.rs
+++ b/src/federation/create_bookmark.rs
@@ -1,10 +1,7 @@
 use activitypub_federation::{
     fetch::object_id::ObjectId,
     kinds::activity::CreateType,
-    protocol::{
-        helpers::deserialize_one_or_many,
-        verification::{verify_domains_match, verify_is_remote_object},
-    },
+    protocol::verification::{verify_domains_match, verify_is_remote_object},
     traits::{ActivityHandler, Object},
 };
 use serde::{Deserialize, Serialize};
@@ -19,8 +16,6 @@ use crate::{
 #[serde(rename_all = "camelCase")]
 pub struct CreateBookmark {
     pub actor: ObjectId<db::ApUser>,
-    #[serde(deserialize_with = "deserialize_one_or_many")]
-    pub to: Vec<Url>,
     pub object: federation::Json,
     #[serde(rename = "type")]
     pub kind: CreateType,
@@ -34,25 +29,23 @@ impl CreateBookmark {
         context: &super::Data,
     ) -> ResponseResult<()> {
         let object = bookmark.into_json(context).await?;
-        let id = super::activity::generate_id(context)?;
+        // Add ?create to id. Activity id has to be distinct from object id.
+        let mut id = object.id.inner().clone();
+        id.set_query(Some("create"));
 
         let mut tx = context.db_pool.begin().await?;
         let followers = db::ap_users::list_followers(&mut tx, actor.id).await?;
-        let to = followers
-            .iter()
-            .map(|ap_user| ap_user.ap_id.clone().into_inner())
-            .collect();
         let create = CreateBookmark {
             actor: actor.ap_id.clone(),
-            to,
             object,
             kind: CreateType::Create,
             id,
         };
 
-        super::activity::send(
+        super::activity::send_with_context(
             actor,
             create,
+            super::activity::hashtag_context(),
             &followers.iter().collect::<Vec<_>>(),
             context,
         )

--- a/src/routes/federation.rs
+++ b/src/routes/federation.rs
@@ -85,7 +85,10 @@ async fn get_bookmark(
     let json_bookmark = bookmark
         .into_json(&state.federation_config.to_request_data())
         .await?;
-    Ok(FederationJson(WithContext::new_default(json_bookmark)))
+    Ok(FederationJson(WithContext::new(
+        json_bookmark,
+        federation::activity::hashtag_context(),
+    )))
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Hello!

This PR adjusts `src/federation/bookmark.rs` and related files so bookmarks made in Ties can be seen in Betula. I tested this on my testing instances of Ties and Betula. Combined with [my recent PR to Betula](https://codeberg.org/bouncepaw/betula/pulls/241) that fixes Betula's HTTP Signatures handling, we get the basic compatibility. There are some adjustments I will have to make on my side for better bookmark rendering, but the protocol representation will remain the same.

Ties currently has no notion of bookmark descriptions or notes. To match the format, I made an empty text/plain description.

Also, instead of tags, there are lists. I'm not sure I'm working with them correctly here, tbh I never managed to see them as tags in Betula: do I call db correctly?

I did not change the HTML representation of the bookmark (`content`).

This is what a Ties profile looks like in Mastodon:

<img width="613" height="924" alt="Screenshot 2026-06-16 at 02 17 08" src="https://github.com/user-attachments/assets/315a457b-d120-464c-89b8-c7b5f03afa07" />

And in Betula (subject to change): 

<img width="659" height="935" alt="Screenshot 2026-06-16 at 02 18 07" src="https://github.com/user-attachments/assets/08edabe8-baef-471f-8088-72042e584b82" />
