### PR TITLE
Extend session expiry on activity

### DIFF
--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -151,6 +151,16 @@ impl AuthUser {
             .context("Failed to load authenticated user id")?
             .ok_or(ResponseError::NotAuthenticated)?;
 
+        // if the session already has a certain age, extend its expiry
+        if session.expiry_age() < time::Duration::days(13) {
+            // We only call `set_expiry` to set the "modified" flag
+            // so a new expiry date is written to the DB,
+            // thus making the session live longer
+            session.set_expiry(Some(tower_sessions::Expiry::OnInactivity(
+                session.expiry_age(),
+            )));
+        }
+
         Ok(Self {
             user_id: value.user_id,
             ap_user_id: value.ap_user_id,


### PR DESCRIPTION
Previously, sessions would always end after two weeks because sessions don't see any activity after login, so their expiration date is never updated.

Now, we move the expiration date into the future as soon as a request comes in and the session hasn't been updated for a day. This makes sessions extend infinitely as long as users keep using the service at least once every two weeks.

Fix #327 